### PR TITLE
ci: replace abandoned pre-commit/action with inline pre-commit run

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Install pre-commit
+        run: python -m pip install --upgrade pip pre-commit
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   perlcritic:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Replace the abandoned `pre-commit/action` GitHub Action with an inline `pre-commit run --all-files` step.

`pre-commit/action` has not had a release since Feb 2024, and upstream recommends running pre-commit directly instead.

Part of #606