### PR TITLE
Replace abandoned ludeeus/action-shellcheck with reviewdog/action-shellcheck

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
+        with:
+          reporter: github-check
+          fail_on_error: "true"
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-auth-server.yml
+++ b/.github/workflows/deploy-auth-server.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
-          scandir: './auth-server'
+          path: './auth-server'
+          reporter: github-check
+          fail_on_error: "true"
 
   check-caddy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-zones.yml
+++ b/.github/workflows/deploy-zones.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
-          scandir: './zones'
+          path: './zones'
+          reporter: github-check
+          fail_on_error: "true"
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ludeeus/action-shellcheck is abandoned (last release Jan 2023). reviewdog/action-shellcheck is actively maintained and gives inline PR annotations. Part of #606.